### PR TITLE
fix: rephrase multiple subtitles and feature description in i18n

### DIFF
--- a/content/i18n/en.json
+++ b/content/i18n/en.json
@@ -143,7 +143,7 @@
         "featured": false,
         "price": { "Monthly": "$0", "Annually": "$0" },
         "description":
-          "You’re new to investing but want to do it right. Get started for free.",
+          "New to AI? Get started for free with our simple solution.",
         "button": {
           "label": "Get started for free",
           "href": "/#download"
@@ -152,7 +152,7 @@
           "Prompt Library",
           "Markdown Rendering",
           "Multiple Models",
-          "Many misc functions",
+          "Various extra features",
           "Upgrade to Pro any time"
         ]
       },
@@ -161,7 +161,7 @@
         "featured": false,
         "price": { "Onetime": "$9.99" },
         "description":
-          "You’ve been investing for a while. Invest more and grow your wealth faster.",
+          "You’ve been using for a while. Unlock a new level of your productivity.",
         "button": {
           "label": "One-time purchase",
           "href": "/#download"
@@ -172,7 +172,7 @@
           "Siri Integration",
           "Text to Speech",
           "Join Team",
-          "More misc functions"
+          "Additional Pro features"
         ]
       },
       {
@@ -181,7 +181,7 @@
         "tag": "Try It Free in 3 Days",
         "price": { "Monthly": "$2.99", "Annually": "$19.99 - Save 44%" },
         "description":
-          "You’ve got a huge amount of assets but it’s not enough. To the moon.",
+          "Supercharge your productivity with our all-in-one AI suite.",
         "button": {
           "label": "Subscribe",
           "href": "/#download"
@@ -242,7 +242,7 @@
       },
       {
         "name": "Siri Integration",
-        "description": "Invest in different industries to find the most opportunities to win huge.",
+        "description": "Access AI chat in no time through Siri Shortcuts without opening the app.",
         "icon": "apple"
       },
       {

--- a/content/i18n/zh-Hans.json
+++ b/content/i18n/zh-Hans.json
@@ -235,7 +235,7 @@
       },
       {
         "name": "Siri 集成",
-        "description": "在不同行业进行投资，寻找最多机会以赢得巨大回报。",
+        "description": "无需打开应用程序，通过快捷指令使用 Siri 与 AI 进行对话。",
         "icon": "apple"
       },
       {


### PR DESCRIPTION
## Detailed description of the change:

I change the subtitles in the pricing section under the `en.json` and a feature description in both `en.json` and `zh-Hans.json`.

## Context of the change:

Personally, I find it slightly confusing and misleading because the app itself has no connection to Investing. Additionally, the subtitles of the pricing section in Chinese mention AI, which leads me to believe there might be a mistake. This same logic applies to the 'Siri Integration' feature description.

I am changing the `many misc functions` to `various extra features` because I think the term `miscellaneous` is kind of not as appropriate in the marketing context?