### PR TITLE
Release OpenCat 2.94.1.2426

### DIFF
--- a/public/releases/versions.xml
+++ b/public/releases/versions.xml
@@ -3,20 +3,29 @@
     <channel>
         <title>OpenCat</title>
         <item>
+            <title>2.94.1</title>
+            <pubDate>Tue, 23 Jun 2026 10:54:48 +0000</pubDate>
+            <link>https://opencat.app</link>
+            <sparkle:version>2426</sparkle:version>
+            <sparkle:shortVersionString>2.94.1</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://releases.opencat.app/OpenCat-2.94.1.2426.dmg" length="45256873" type="application/octet-stream" sparkle:edSignature="WRnfKu12LCiqLo1GajOGdCfvPncmNGvH/PtIcnf9q8461rZYX5eum/NKNlRb2hwHKLtY8itPA0D3413IFM6gCw=="/>
+            <sparkle:deltas>
+                <enclosure url="https://releases.opencat.app/OpenCat2426-2418.delta" sparkle:deltaFrom="2418" length="3064990" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="LNktRBUmtIL8xUKQ74suxGBsUFsiTUGl8E3Y6ZW0xEcWFmmbqrV64iWeKTcxDXID4WFfENJOo21H9+DKFalWBg=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2426-2395.delta" sparkle:deltaFrom="2395" length="11210778" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="93+ygwpTyx1wcdl6kk7JQ1oiMEBCChuTYqEZ/2vRPWPG4ec5hU9B+4O2tkwPhf3RyRr95sxwTf+eogwZBeBiDw=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2426-2379.delta" sparkle:deltaFrom="2379" length="11296818" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="crApXZq2MvlCfKxyMA0nU4zpXml0LPtcXIfk6+kGUnbhkf2k0YXPJmBbruAln6XpqS24+Bdk3DAbz5zFKec8Aw=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2426-2369.delta" sparkle:deltaFrom="2369" length="11343210" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="kMxy9Z9EGgqiv6+PIo/mD2oFDaKYzdhSppcIv/vvkX/MC7hxZpz4xmgVsxqfuAS4h41JrT6R7ya9yzodeQ3BBQ=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2426-2339.delta" sparkle:deltaFrom="2339" length="11482610" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="ZRD8Al8QkCa/Xp+sXtlt79IiBE9mpZMdgCuGNtNpBFMIX1XkB8xoPUX82be+BS1AUATK15eapj3JA22rgyrKDA=="/>
+            </sparkle:deltas>
+        </item>
+        <item>
             <title>2.94.0</title>
-            <pubDate>Mon, 15 Jun 2026 16:42:57 +0000</pubDate>
+            <pubDate>Mon, 15 Jun 2026 16:43:02 +0000</pubDate>
             <link>https://opencat.app</link>
             <sparkle:version>2418</sparkle:version>
             <sparkle:shortVersionString>2.94.0</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
             <enclosure url="https://releases.opencat.app/OpenCat-2.94.0.2418.dmg" length="45254462" type="application/octet-stream" sparkle:edSignature="evgPuKDU39pF22bT7dHWpv+D3RMeY4tcJFNcnCI3tFE9H1xFWrRTYYPYmludJ+H22/TxTzDKg/o6fpC2KfkgCw=="/>
-            <sparkle:deltas>
-                <enclosure url="https://releases.opencat.app/OpenCat2418-2395.delta" sparkle:deltaFrom="2395" length="11171670" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="yvHkHPWq76vUAu+5RB+B8m2kOsequfaiq5+HnKXcRQxWlBasD6Xc0xEbCTc4jy96fS0ap/FhmOi3FIl3YUz+DQ=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2418-2379.delta" sparkle:deltaFrom="2379" length="11253298" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="nJ4IX4t8ZmPzZwvxN+rTc0rYgWbC2YXo4oUz5y16XJ19zhr6zr0c60+zqTI8DnX2L0UBiQWA1xrIKDqSNh+XCQ=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2418-2369.delta" sparkle:deltaFrom="2369" length="11292070" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="eetIPlARv6YtUG4scKt0HX77BSBgCsZarkO8clcGiv1nVR+0Wec2b4/wCMAt7Y2yVCQPS9zL10ZIkmhkVWw4Dg=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2418-2339.delta" sparkle:deltaFrom="2339" length="11455766" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="Uxy7LQZmZDAOyIxNCMGrZO2iJYLsUDRmkpJFWBd+HG/YJR1jAHXdzoeypdcrvHbO6KCzaaubW0wLD/BZ/0BPAA=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2418-2300.delta" sparkle:deltaFrom="2300" length="19528774" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="0PBrNgTH+i05SmMI+Jr7XDb+Rt6HK9jGMPOVpiYzOpWVtLpmZ54UgeVTOWDRP+5EP+iLWGzTyZ9wN1OC/oHlAA=="/>
-            </sparkle:deltas>
         </item>
         <item>
             <title>2.93.2</title>
@@ -44,15 +53,6 @@
             <sparkle:shortVersionString>2.93.0</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
             <enclosure url="https://releases.opencat.app/OpenCat-2.93.0.2369.dmg" length="40300017" type="application/octet-stream" sparkle:edSignature="NnR7O3dlaAtxSsAmkQqjmeW81tIwxXCUwGBdraUoGknrfQoCyVKX6o54yFLIGlXW9MtFZGQ5yR4JNaBzTukZAQ=="/>
-        </item>
-        <item>
-            <title>2.92.5</title>
-            <pubDate>Tue, 02 Jun 2026 08:32:34 +0000</pubDate>
-            <link>https://opencat.app</link>
-            <sparkle:version>2339</sparkle:version>
-            <sparkle:shortVersionString>2.92.5</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://releases.opencat.app/OpenCat-2.92.5.2339.dmg" length="40915083" type="application/octet-stream" sparkle:edSignature="vBPNk3LbDmsYpgA6eRl5d4zBEgSoX+qZtKv2dsSQILpF3d85rds6cNb4Q/Pekt0amFrBTfU8OxJJIPNGBuiKAQ=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Automated appcast update for `dedicated-v2.94.1`. Binaries are already on R2; merging publishes the update to all Sparkle clients.