### PR TITLE
feat(i18n): 根路径默认直出英文，仅非默认语言才重定向

### DIFF
--- a/src/components/HomePage.astro
+++ b/src/components/HomePage.astro
@@ -1,0 +1,42 @@
+---
+import type { Locale } from '@/utils/i18n-config'
+import { getDictionary } from '@/utils/get-dictionary'
+import Layout from '@/layouts/Layout.astro'
+import { Header } from '@/components/Header'
+import { Hero } from '@/components/Hero'
+import { PrimaryFeatures } from '@/components/PrimaryFeatures'
+import { SecondaryFeatures } from '@/components/SecondaryFeatures'
+import { CallToAction } from '@/components/CallToAction'
+import { Reviews } from '@/components/Reviews'
+import { Pricing } from '@/components/Pricing'
+import { Faqs } from '@/components/Faqs'
+import { Resources } from '@/components/Resources'
+import { Footer } from '@/components/Footer'
+
+interface Props {
+  lang: Locale
+  /** 规范链接路径；裸 "/" 直出英文时显式指向 "/en/"，避免与本地化页重复。 */
+  canonicalPath?: string
+}
+
+const { lang, canonicalPath } = Astro.props
+const dict = await getDictionary(lang)
+---
+
+<Layout lang={lang} canonicalPath={canonicalPath}>
+  {/* Header 含移动端菜单 / 语言切换，需立即可交互 */}
+  <Header client:load params={{ links: dict.links, button: dict.button, doc: dict.doc }} />
+  <main class="flex-auto">
+    <Hero params={{ hero: dict.hero }} />
+    {/* 折叠下方的交互区块进入视口再 hydrate */}
+    <PrimaryFeatures client:visible params={{ feature: dict.feature }} />
+    <SecondaryFeatures params={{ secondaryFeature: dict['secondary-feature'] }} />
+    <CallToAction params={{ cta: dict.cta }} />
+    <Reviews client:visible params={{ review: dict.review }} />
+    <Pricing client:visible params={{ pricing: dict.pricing }} />
+    <Faqs params={{ faq: dict.faq }} />
+    <Resources params={{ resource: dict.resource }} />
+  </main>
+  {/* Footer 内含 NavLinks 悬停动画与 ContactLink 邮箱解码，需 hydrate */}
+  <Footer client:visible params={{ footer: dict.footer, links: dict.links }} />
+</Layout>

--- a/src/components/I18nSwitch.tsx
+++ b/src/components/I18nSwitch.tsx
@@ -16,8 +16,14 @@ export default function I18nSwitch() {
     if (!pathName)
       return '/'
     const segments = pathName.split('/')
-    segments[1] = locale
-    return segments.join('/')
+    // segments[1] 是首段：本地化页为语言码；裸 "/"（英文直出）下为空串。
+    if ((i18n.locales as readonly string[]).includes(segments[1]))
+      segments[1] = locale // 替换已有语言前缀
+    else
+      segments.splice(1, 0, locale) // 根路径等无前缀场景：插入语言段
+    const path = segments.join('/')
+    // 站点统一带尾斜杠（trailingSlash: 'always'），补全以免命中跳转。
+    return path.endsWith('/') ? path : `${path}/`
   }
 
   return (

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,19 +7,26 @@ interface Props {
   /** 页面标题；省略时用站点默认标题。传入时按 "%s - OpenCat" 模板拼接。 */
   title?: string
   description?: string
+  /**
+   * 规范链接路径；省略时取当前请求路径。
+   * 当同一份内容在多个 URL 可达（如裸 "/" 直出英文首页，与 "/en/" 同内容）时，
+   * 由调用方显式指向唯一规范 URL，避免重复内容。
+   */
+  canonicalPath?: string
 }
 
 const {
   lang,
   title,
   description = 'OpenCat is a native AI client, offering a smoother and faster chat experience than the web.',
+  canonicalPath,
 } = Astro.props
 
 const defaultTitle = 'OpenCat - ChatGPT app client for Mac/iOS/iPad'
 const pageTitle = title ? `${title} - OpenCat` : defaultTitle
 const keywords = 'opencat,open cat,desktop ai chat ,ios ai chat, macos ai chat, better ui chatgpt，chat gpt ui'
 
-const canonical = new URL(Astro.url.pathname, Astro.site)
+const canonical = new URL(canonicalPath ?? Astro.url.pathname, Astro.site)
 ---
 
 <!doctype html>

--- a/src/pages/[lang]/index.astro
+++ b/src/pages/[lang]/index.astro
@@ -1,17 +1,6 @@
 ---
 import { type Locale, i18n } from '@/utils/i18n-config'
-import { getDictionary } from '@/utils/get-dictionary'
-import Layout from '@/layouts/Layout.astro'
-import { Header } from '@/components/Header'
-import { Hero } from '@/components/Hero'
-import { PrimaryFeatures } from '@/components/PrimaryFeatures'
-import { SecondaryFeatures } from '@/components/SecondaryFeatures'
-import { CallToAction } from '@/components/CallToAction'
-import { Reviews } from '@/components/Reviews'
-import { Pricing } from '@/components/Pricing'
-import { Faqs } from '@/components/Faqs'
-import { Resources } from '@/components/Resources'
-import { Footer } from '@/components/Footer'
+import HomePage from '@/components/HomePage.astro'
 
 export const prerender = true
 
@@ -20,23 +9,6 @@ export function getStaticPaths() {
 }
 
 const { lang } = Astro.params as { lang: Locale }
-const dict = await getDictionary(lang)
 ---
 
-<Layout lang={lang}>
-  {/* Header 含移动端菜单 / 语言切换，需立即可交互 */}
-  <Header client:load params={{ links: dict.links, button: dict.button, doc: dict.doc }} />
-  <main class="flex-auto">
-    <Hero params={{ hero: dict.hero }} />
-    {/* 折叠下方的交互区块进入视口再 hydrate */}
-    <PrimaryFeatures client:visible params={{ feature: dict.feature }} />
-    <SecondaryFeatures params={{ secondaryFeature: dict['secondary-feature'] }} />
-    <CallToAction params={{ cta: dict.cta }} />
-    <Reviews client:visible params={{ review: dict.review }} />
-    <Pricing client:visible params={{ pricing: dict.pricing }} />
-    <Faqs params={{ faq: dict.faq }} />
-    <Resources params={{ resource: dict.resource }} />
-  </main>
-  {/* Footer 内含 NavLinks 悬停动画与 ContactLink 邮箱解码，需 hydrate */}
-  <Footer client:visible params={{ footer: dict.footer, links: dict.links }} />
-</Layout>
+<HomePage lang={lang} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,19 @@
 ---
+import { i18n } from '@/utils/i18n-config'
 import { detectLocale } from '@/utils/locale'
+import HomePage from '@/components/HomePage.astro'
 
-// 裸路径 "/" → 按 Accept-Language 重定向到带语言前缀的首页（302：随浏览器语言而变，非永久）。
+// 裸路径 "/"：按 Accept-Language 协商语言。
+// 默认语言（en）直接在 "/" 直出英文首页，避免无谓的一次跳转；
+// 其它语言才 302 重定向到带语言前缀的本地化首页（302：随浏览器语言而变，非永久）。
 export const prerender = false
 
-return Astro.redirect(`/${detectLocale(Astro.request)}/`, 302)
+const locale = detectLocale(Astro.request)
+
+if (locale !== i18n.defaultLocale) {
+  return Astro.redirect(`/${locale}/`, 302)
+}
 ---
+
+{/* canonical 指向 "/en/"（sitemap 收录的规范本地化 URL），与 "/" 同内容不重复计权。 */}
+<HomePage lang={i18n.defaultLocale} canonicalPath={`/${i18n.defaultLocale}/`} />


### PR DESCRIPTION
## 背景

访问主页 `/` 时，目前对**所有**语言（包括英文）都会做一次 302 跳转到带语言前缀的本地化首页（`/en/` 或 `/zh-Hans/`）。英文用户也要白白经历一次跳转，体验不佳。

## 改动

裸 `/` 仍按 `Accept-Language` 协商语言，但逻辑改为：

- **默认语言 en** → 直接在 `/` 渲染英文首页（`200`，无跳转）
- **其它语言**（如 zh-Hans）→ `302` 跳到 `/{locale}/`

| 请求 | Accept-Language | 结果 |
|---|---|---|
| `/` | en / 无 / 不支持的语言 | **200 直出英文** |
| `/` | zh | **302 → `/zh-Hans/`** |

### 具体变更

- **`src/components/HomePage.astro`（新增）** —— 抽出共享首页组件，`/` 与 `/[lang]/` 复用同一份内容，避免重复。
- **`src/pages/index.astro`** —— 默认语言直出英文，仅非默认语言重定向。
- **`src/pages/[lang]/index.astro`** —— 精简为复用 `HomePage`。
- **`src/layouts/Layout.astro`** —— 新增可选 `canonicalPath`；`/` 的 canonical 指向 `/en/`，与 `/en/` 同内容不重复计权（sitemap 仍只收录 `/en/`，不含裸 `/`）。
- **`src/components/I18nSwitch.tsx`** —— 修复因此引入的 bug：根路径无语言前缀时，语言切换会生成缺尾斜杠的 `/en`；现在能正确插入语言段并补全尾斜杠。

## 验证

- `pnpm build` 通过，`/en/`、`/zh-Hans/` 仍为静态预渲染，`/` 走 on-demand worker。
- wrangler dev 实测：en/无/fr 直出 200；zh 302 跳 `/zh-Hans/`；`/` 与 `/en/` 的 canonical 均为 `https://opencat.app/en/`。
- sitemap 不含裸 `/`。

> 注：`pnpm astro check` 中 `release.ts` 的 `cloudflare:workers` 类型 error 为既有问题（需 `pnpm cf-typegen`），与本次改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)