### PR TITLE
Release OpenCat 26.7.0.2442

### DIFF
--- a/public/releases/versions.xml
+++ b/public/releases/versions.xml
@@ -3,20 +3,29 @@
     <channel>
         <title>OpenCat</title>
         <item>
+            <title>26.7.0</title>
+            <pubDate>Wed, 01 Jul 2026 06:20:56 +0000</pubDate>
+            <link>https://opencat.app</link>
+            <sparkle:version>2442</sparkle:version>
+            <sparkle:shortVersionString>26.7.0</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://releases.opencat.app/OpenCat-26.7.0.2442.dmg" length="45288506" type="application/octet-stream" sparkle:edSignature="ytCtArBl+MOqbg+Jvwzfwp2oEciv+OWgEu8YQu16txfV+w/nEGsr3PKofFehtv2nafLMkhxvB7AZoH9iiMavDQ=="/>
+            <sparkle:deltas>
+                <enclosure url="https://releases.opencat.app/OpenCat2442-2433.delta" sparkle:deltaFrom="2433" length="3753546" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="EVB7JpxyX2458/rJbSkpWNkWqqgfuTcsfDleVDJyt43yS9PPSYy95KsILa+u9iGEJuOm2wWQbDMz1wNUihfrCg=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2442-2426.delta" sparkle:deltaFrom="2426" length="3848926" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="gXZBikfeXR1+mrS0S4xjd1vgrsc68azqSVjLorGADEudUS9aBNILZpyv06Oc0zd0VIYIhS3rsJdon/T1RvyNAA=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2442-2418.delta" sparkle:deltaFrom="2418" length="4037606" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="hIzrVcYWIYwQ/vB6zW1RU+W9/AxoLJ17VOTFqiDabx9kaJTFEa8Lkqf8G5O/a9odYnZoB+yVCw16vjz7JN/wCw=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2442-2395.delta" sparkle:deltaFrom="2395" length="11292030" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="e/Mv2YIe8eWGNrAX7pGPURUgaS1ji2k2ReJ9RLAORb2ADPZjXv4EvX2xiAg9I0nCOH4GVWWF0LMpSQOSyieWCQ=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2442-2379.delta" sparkle:deltaFrom="2379" length="11357198" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="XejpfChHczS2exYpZ/Zt2e1s0+JCrEQfyLfO3x/KwM1XBCgPmxMRpmu+Nen+D68xlzqc9sGXb2yk2U0ljPHMCQ=="/>
+            </sparkle:deltas>
+        </item>
+        <item>
             <title>2.94.2</title>
-            <pubDate>Mon, 29 Jun 2026 10:15:29 +0000</pubDate>
+            <pubDate>Mon, 29 Jun 2026 10:15:33 +0000</pubDate>
             <link>https://opencat.app</link>
             <sparkle:version>2433</sparkle:version>
             <sparkle:shortVersionString>2.94.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
             <enclosure url="https://releases.opencat.app/OpenCat-2.94.2.2433.dmg" length="45273500" type="application/octet-stream" sparkle:edSignature="jb/ybmDN2poGNO2/IxItaJgiwdYfQf47AsWMJsYJ2tSRO9FsDGK/rVHoRQN77bv8vcEDRq9++2o5jAycA0+iCA=="/>
-            <sparkle:deltas>
-                <enclosure url="https://releases.opencat.app/OpenCat2433-2426.delta" sparkle:deltaFrom="2426" length="3157710" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="3Iq/P9YHslnN4dI6wf/cYA71xNiuTUzddIuHVLPkVvamSASvrn3WtC6+6+LTq3C65fLNciu7BBlX4gETKIDfAQ=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2433-2418.delta" sparkle:deltaFrom="2418" length="3457862" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="wsy0K6XCDoe5pYblR8bpqT3vOUeYnssy2Bh0X0u1YMHa5CQQvpJ8BlrJGhCBV4vt+9EBLFvAcKWmrvXLCAxYBw=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2433-2395.delta" sparkle:deltaFrom="2395" length="11214858" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="7nsVViyWPB4y652Ys6u1tmAMlbai02Z8Z1ncYyXrG3pcqZc7P/hTPJ+E9+XhTXH14Pca4A6QqHbkXzDOw8kpDg=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2433-2379.delta" sparkle:deltaFrom="2379" length="11325650" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="dtfp05+18xH4Ho2bnmHZiQiexAeKIbOMEEoSbSEtbebE3MaxhprIoafq56mrY8fJQUV5qoWsFpTQg3e+7Ke6BQ=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2433-2369.delta" sparkle:deltaFrom="2369" length="11356870" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="3ZnTCCUJhgRhcXeE/NEAEqK1hHHovOLMfvJlIbEOUaQTNvXsEkQACQ6QV23fOk+ThjseY6yxAP/pTJCJVyTrDw=="/>
-            </sparkle:deltas>
         </item>
         <item>
             <title>2.94.1</title>
@@ -44,15 +53,6 @@
             <sparkle:shortVersionString>2.93.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
             <enclosure url="https://releases.opencat.app/OpenCat-2.93.2.2395.dmg" length="40324161" type="application/octet-stream" sparkle:edSignature="fQq40A7yujYCAjzDT499GDad1HC2M73/dIDfSQEgmQiExWMLOTR74hSqqCzYy4J3c0MCpLbS3M5UwToKM+dtDA=="/>
-        </item>
-        <item>
-            <title>2.93.1</title>
-            <pubDate>Thu, 04 Jun 2026 11:06:57 +0000</pubDate>
-            <link>https://opencat.app</link>
-            <sparkle:version>2379</sparkle:version>
-            <sparkle:shortVersionString>2.93.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://releases.opencat.app/OpenCat-2.93.1.2379.dmg" length="40330047" type="application/octet-stream" sparkle:edSignature="71Yi1HDVPSWqki/hwgt1v+WBK7dJmHis49880jFRuJ6AaPGflPH+/G+aXM+bnEJlPZCkY1s1u6+xApuvSPdKDA=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Automated appcast update for `dedicated-v26.7.0`. Binaries are already on R2; merging publishes the update to all Sparkle clients.