### PR TITLE
Release OpenCat 26.7.3.2506

### DIFF
--- a/public/releases/versions.xml
+++ b/public/releases/versions.xml
@@ -3,20 +3,29 @@
     <channel>
         <title>OpenCat</title>
         <item>
+            <title>26.7.3</title>
+            <pubDate>Fri, 24 Jul 2026 16:11:42 +0000</pubDate>
+            <link>https://opencat.app</link>
+            <sparkle:version>2506</sparkle:version>
+            <sparkle:shortVersionString>26.7.3</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
+            <enclosure url="https://releases.opencat.app/OpenCat-26.7.3.2506.dmg" length="46301859" type="application/octet-stream" sparkle:edSignature="WIPoNKcTWB+LbDJBU1jHy6XfNkt3aWtGaKWLHLyeJnb2Q1SaJp4dJZoluP2xOPu5BacQihJimavuD5OF8vOJDA=="/>
+            <sparkle:deltas>
+                <enclosure url="https://releases.opencat.app/OpenCat2506-2472.delta" sparkle:deltaFrom="2472" length="4738598" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="9r9OGduxdAk7O662v3rU5eNTCB3FXx8gTz8u+rzI7rtUluvVSFd63tN3KEjNLhai8Fae4S5HIADPArpEOhw0Dw=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2506-2463.delta" sparkle:deltaFrom="2463" length="4763446" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="6Ygz0gsR5Xg+oEwAZCpOA6ZOtTqcNH6vGfOnE3NBoT+9w0tTUx6EEY+EQEx8GExs5ZazLFBduBeGLgvZwZDwDw=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2506-2442.delta" sparkle:deltaFrom="2442" length="12424774" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="5uECJFDd1yfRa6V4Rlu1zYxua9r81HHwMvFZD5xRIV6FBwcb6s3OFeiWpjiE3TYxkHWQcKR8D2ejk/vPr7KZAg=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2506-2433.delta" sparkle:deltaFrom="2433" length="12443166" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="gnjpw1qCzy5cJQ6X5rNtNs7Y9iGB7/PQnL/O+W5IDQLyE6++bk4ZlpysrEYlLg9giVl0r+tVhklJNCH7MBHyCQ=="/>
+                <enclosure url="https://releases.opencat.app/OpenCat2506-2426.delta" sparkle:deltaFrom="2426" length="12484294" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="J/R+YN8E0VOFul3RvIM30S3GVf+r97Ni2AxOX3GxkbL3GcHXRO3ZkD6i+jS+RoLW09BUVLbkhAVrKQtOZe2iCw=="/>
+            </sparkle:deltas>
+        </item>
+        <item>
             <title>26.7.2</title>
-            <pubDate>Fri, 10 Jul 2026 03:51:54 +0000</pubDate>
+            <pubDate>Fri, 10 Jul 2026 03:51:58 +0000</pubDate>
             <link>https://opencat.app</link>
             <sparkle:version>2472</sparkle:version>
             <sparkle:shortVersionString>26.7.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
             <enclosure url="https://releases.opencat.app/OpenCat-26.7.2.2472.dmg" length="46219216" type="application/octet-stream" sparkle:edSignature="fKamXIKf5jeEX5zRNVNI8E8R/2jMTccXeZMCXae17stBuPqHPOaJx/CRjLnTpOFTl03ETK9/W5FBTiL49LFrAQ=="/>
-            <sparkle:deltas>
-                <enclosure url="https://releases.opencat.app/OpenCat2472-2463.delta" sparkle:deltaFrom="2463" length="3273138" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="vTQIEiPpwDvmDMSPejjacF3JGnz0WXfs0craTiaJowU4F4UsPqVsplDe3cp+hK1nHnQPN1xTjQEeA8/9bdr4DA=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2472-2442.delta" sparkle:deltaFrom="2442" length="12133950" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="t/GlA/5iiRLf51v0m1Rih9lK0jUo/ZpqRU8q2RK4I1YOclxhOQ1zuF7EoTS3OWp9qiqU0nJ1fJ6e7YNdsC08Dg=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2472-2433.delta" sparkle:deltaFrom="2433" length="12233010" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="1vyjzkiVp9LnWehR5C4uQNAwh+oO4QurmTrWXujH8PkNFNgPSmMxozQWzPCvjE/PZ7gF/oK5MW5Zjj1TRfWIAg=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2472-2426.delta" sparkle:deltaFrom="2426" length="12238606" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="bdzP1X05f6BAdBC29v6mSJX5YA2QRluActFREnVnPAI7XcodLb8pBB+dEgaTxMW0Um2kaLoITzGz1xA4SOfABg=="/>
-                <enclosure url="https://releases.opencat.app/OpenCat2472-2418.delta" sparkle:deltaFrom="2418" length="12248014" type="application/octet-stream" sparkle:deltaFromSparkleExecutableSize="977840" sparkle:deltaFromSparkleLocales="de,he,ar,el,ja,fa,uk" sparkle:edSignature="nMF/4ySZtu75iDjZmrfPbNuO9UYXwA7FQwjW27BRKDON2pMomq+UNbIM8lWu5uvJ0wcTPXrm5lRXZBka0IuNBQ=="/>
-            </sparkle:deltas>
         </item>
         <item>
             <title>26.7.1</title>
@@ -44,15 +53,6 @@
             <sparkle:shortVersionString>2.94.2</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
             <enclosure url="https://releases.opencat.app/OpenCat-2.94.2.2433.dmg" length="45273500" type="application/octet-stream" sparkle:edSignature="jb/ybmDN2poGNO2/IxItaJgiwdYfQf47AsWMJsYJ2tSRO9FsDGK/rVHoRQN77bv8vcEDRq9++2o5jAycA0+iCA=="/>
-        </item>
-        <item>
-            <title>2.94.1</title>
-            <pubDate>Tue, 23 Jun 2026 10:54:53 +0000</pubDate>
-            <link>https://opencat.app</link>
-            <sparkle:version>2426</sparkle:version>
-            <sparkle:shortVersionString>2.94.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure url="https://releases.opencat.app/OpenCat-2.94.1.2426.dmg" length="45256873" type="application/octet-stream" sparkle:edSignature="WRnfKu12LCiqLo1GajOGdCfvPncmNGvH/PtIcnf9q8461rZYX5eum/NKNlRb2hwHKLtY8itPA0D3413IFM6gCw=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
Automated appcast update for `dedicated-v26.7.3`. Binaries are already on R2; merging publishes the update to all Sparkle clients.